### PR TITLE
fix: run snyk monitor only on release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,13 +81,18 @@ jobs:
 
   snyk-oss:
     executor: default
+    parameters:
+      run-monitor:
+        description: run snyk monitor if true
+        type: boolean
+        default: false
     steps:
       - run-with-go-cache:
           tag: snyk-oss
           steps:
             - snyk/scan:
                 severity-threshold: high
-                monitor-on-build: true
+                monitor-on-build: << parameters.run-monitor >>
                 project: ${CIRCLE_PROJECT_REPONAME}
                 organization: snyk-iac-group-seceng
 
@@ -166,6 +171,7 @@ workflows:
       - snyk-oss:
           name: Snyk Open Source
           context: snyk-iac-capture
+          run-monitor: true
       - snyk-code:
           name: Snyk Code
           context: snyk-iac-capture


### PR DESCRIPTION
Only run `snyk monitor` on release workflow (e.g. when push on main)