### PR TITLE
chore: simplify release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,19 +172,14 @@ workflows:
       - snyk-code:
           name: Snyk Code
           context: snyk-iac-capture
-      - hold:
-          name: Approve release
-          type: approval
-          requires:
-            - Tidy
-            - Format
-            - Build
-            - Test
-            - Lint
-            - Snyk Open Source
-            - Snyk Code
       - release:
           name: Release
           context: snyk-iac-capture
           requires:
-            - Approve release
+              - Tidy
+              - Format
+              - Build
+              - Test
+              - Lint
+              - Snyk Open Source
+              - Snyk Code

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,8 +26,3 @@ changelog:
   filters:
     exclude:
       - '^Merge pull request'
-blobs:
-  - provider: s3
-    bucket: snyk-assets
-    region: us-east-1
-    folder: "cli/iac/capture/{{.Tag}}"


### PR DESCRIPTION
### What this does

- Remove upload binaries to s3 bucket since it is not used anymore
- Remove manual approval step to generate releases on main

### Post-merge actions

- [x] Remove AWS secrets from CircleCI