### PR TITLE
chore: secrets scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  prodsec: snyk/prodsec-orb@1.0
   snyk: snyk/snyk@1.4.0
 
 executors:
@@ -126,6 +127,11 @@ workflows:
     unless:
       equal: [ <<pipeline.git.branch>>, main ]
     jobs:
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: group-infrastructure-as-code-alerts
       - tidy:
           name: Tidy
           context: snyk-iac-capture

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+506c0e84775d80f22b843018275ec7d8d7164d85:pkg/config.go:generic-api-key:13

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.2
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Adds secrets scanning to the repository. The scan runs in the CI/CD pipeline and is provide as a pre-commit hook as well.