### PR TITLE
fix: send an empty resources array instead of `null` for empty states

### DIFF
--- a/internal/filtering/statefilter.go
+++ b/internal/filtering/statefilter.go
@@ -25,6 +25,7 @@ func FilterState(state *terraform.State) (*terraform.State, error) {
 		Version:          state.Version,
 		TerraformVersion: state.TerraformVersion,
 		Lineage:          state.Lineage,
+		Resources:        []terraform.Resource{},
 	}
 
 	for _, resource := range state.Resources {

--- a/internal/filtering/statefilter_test.go
+++ b/internal/filtering/statefilter_test.go
@@ -39,6 +39,12 @@ func TestFilter(t *testing.T) {
 			wantErr:        false,
 		},
 		{
+			name:           "Filter a valid but empty state",
+			stateFile:      "empty.json",
+			resultJsonFile: "empty-filtered.json",
+			wantErr:        false,
+		},
+		{
 			name:           "Filter a state with security group rules",
 			stateFile:      "aws_security_group_rule.json",
 			resultJsonFile: "aws_security_group_rule-filtered.json",

--- a/internal/filtering/testdata/empty-filtered.json
+++ b/internal/filtering/testdata/empty-filtered.json
@@ -1,0 +1,8 @@
+{
+  "version": 4,
+  "terraform_version": "1.2.2",
+  "serial": 24,
+  "lineage": "7b1d2096-22d5-4529-b920-d69899aaf0da",
+  "outputs": {},
+  "resources": []
+}

--- a/internal/filtering/testdata/empty.json
+++ b/internal/filtering/testdata/empty.json
@@ -1,0 +1,9 @@
+{
+  "version": 4,
+  "terraform_version": "1.2.2",
+  "serial": 24,
+  "lineage": "7b1d2096-22d5-4529-b920-d69899aaf0da",
+  "outputs": {},
+  "resources": [],
+  "check_results": null
+}


### PR DESCRIPTION
Fixes [IAC-2652](https://snyksec.atlassian.net/browse/IAC-2652)

### What this does

Sets the default value of the `resources` key in the upload API request to be an empty array. This used to be Go's default value for the slice type, which is `nil`, or `null` in JSON, which failed the array OpenAPI type validation.

### More information

- [Jira ticket IAC-2652](https://snyksec.atlassian.net/browse/IAC-2652)


[IAC-2652]: https://snyksec.atlassian.net/browse/IAC-2652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ